### PR TITLE
OPENRESTY-127 HTTPS healthchecks issue

### DIFF
--- a/ngx_http_upstream_check_module.c
+++ b/ngx_http_upstream_check_module.c
@@ -1226,6 +1226,9 @@ ngx_http_upstream_check_ssl_init(ngx_http_upstream_check_peer_t *peer,
     return;
 
 failed:
+    // Connection needs to be set to failed
+    // SSL handshake fail doesn't mean as failed connection, but in the healthcheck case it does
+    c->error = 1;
     ngx_http_upstream_check_status_update(peer, 0);
     ngx_http_upstream_check_clean_event(peer);
 }
@@ -1243,6 +1246,9 @@ ngx_http_upstream_check_ssl_handshake(ngx_connection_t *c)
         ngx_del_timer(c->read);
 
     if (!c->ssl->handshaked) {
+        // Connection needs to be set to failed
+        // SSL handshake fail doesn't mean as failed connection, but in the healthcheck case it does
+        c->error = 1;
         ngx_http_upstream_check_status_update(peer, 0);
         ngx_http_upstream_check_clean_event(peer);
         return;


### PR DESCRIPTION
It seems that fails on ssl handshake makes healthchecks to stop working.
The fix seems to fix the issue (I was not able to reproduce it). The issue was that if the ssl fails the connection is not set as failed. The health check thinks that the connection is valid and waits till it is resolved. However, internally the connection is dropped and the callback functions are not run (which should check the connection), leaving the health check status not changed.   