### PR TITLE
OPENRESTY-111 Configurable SSL healthcheck protocols

### DIFF
--- a/ngx_http_upstream_check_module.c
+++ b/ngx_http_upstream_check_module.c
@@ -3339,7 +3339,7 @@ ngx_http_upstream_check(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     ucscf->default_down = default_down;
     ucscf->ssl = ssl;
     // The default ssl protocols
-    ucscf->ssl_protocols = NGX_SSL_TLSv1|NGX_SSL_SSLv2|NGX_SSL_SSLv3;
+    ucscf->ssl_protocols = NGX_SSL_SSLv2|NGX_SSL_SSLv3|NGX_SSL_TLSv1|NGX_SSL_TLSv1_1|NGX_SSL_TLSv1_2;
 
     if (ucscf->check_type_conf == NGX_CONF_UNSET_PTR) {
         ngx_str_set(&s, "tcp");


### PR DESCRIPTION
Based on previous fix https://github.com/zenedge/nginx_upstream_check_module/pull/5 

This add a new feature to specify the SSL protocols for the `upstream` using `upstream_check module` and a new directive `check_ssl_protocols`.
Example:
`check_ssl_protocols SSLv2 SSLv3 TLSv1 TLSv1.1 TLSv1.2;`
Also updated the default protocols to include all the example protocols.