### PR TITLE
SNI support for SSL HealthChecks

### DIFF
--- a/README
+++ b/README
@@ -124,6 +124,20 @@ Directives
     description: If specified and check type is set to "http" - healthcheck will search for the
     given substring in the response body and will fail if the substring is not found
 
+  check_ssl_server_name
+    syntax: *check_ssl_server_name server_name*
+
+    default: *none*
+
+    context: *upstream*
+
+    description: If specified and check type="http" and ssl=true - healthcheck will try to send the
+    configured server_name in SNI when making the SSL connection.
+    *NOTE*: for this to work - the OpenSSL library that Nginx is built against has to support
+    the SNI TLS extension (`SSL_set_tlsext_host_name()` function). If this function is not
+    supported - "check_ssl_server_name" parameter for healthchecks will not be available in the
+    built Nginx (you will get a configuration error if this directive is used).
+
   check_keepalive_requests
     syntax: *check_keepalive_requests num*
 

--- a/ngx_http_upstream_check_module.c
+++ b/ngx_http_upstream_check_module.c
@@ -247,6 +247,7 @@ struct ngx_http_upstream_check_srv_conf_s {
     ngx_uint_t                               default_down;
     ngx_uint_t                               ssl;
     ngx_uint_t                               ssl_protocols;
+    ngx_str_t                                ssl_server_name;
 };
 
 
@@ -469,6 +470,9 @@ static char *ngx_http_upstream_check_fastcgi_params(ngx_conf_t *cf,
 static char *ngx_http_upstream_check_ssl_protocols(ngx_conf_t *cf,
     ngx_command_t *cmd, void *conf);
 
+static char *ngx_http_upstream_check_ssl_server_name(ngx_conf_t *cf,
+    ngx_command_t *cmd, void *conf);
+
 static char *ngx_http_upstream_check_shm_size(ngx_conf_t *cf,
     ngx_command_t *cmd, void *conf);
 
@@ -548,6 +552,13 @@ static ngx_command_t  ngx_http_upstream_check_commands[] = {
     { ngx_string("check_ssl_protocols"),
       NGX_HTTP_UPS_CONF|NGX_CONF_1MORE,
       ngx_http_upstream_check_ssl_protocols,
+      0,
+      0,
+      NULL },
+
+    { ngx_string("check_ssl_server_name"),
+      NGX_HTTP_UPS_CONF|NGX_CONF_TAKE1,
+      ngx_http_upstream_check_ssl_server_name,
       0,
       0,
       NULL },
@@ -1227,6 +1238,20 @@ ngx_http_upstream_check_ssl_init(ngx_http_upstream_check_peer_t *peer,
     if (ngx_ssl_create(&peer->ssl, ucscf->ssl_protocols, NULL) != NGX_OK ||
         ngx_ssl_create_connection(&peer->ssl, c, flags) != NGX_OK) {
         goto failed;
+    }
+
+    if (ucscf->ssl_server_name.len != 0) {
+        ngx_log_debug2(NGX_LOG_DEBUG_HTTP, c->log, 0,
+            "http check - using ssl server name: \"%*s\"",
+            ucscf->ssl_server_name.len, ucscf->ssl_server_name.data);
+#ifdef SSL_CTRL_SET_TLSEXT_HOSTNAME
+        if (SSL_set_tlsext_host_name(c->ssl->connection, ucscf->ssl_server_name.data) == 0) {
+            goto failed;
+        }
+#else
+        ngx_log_error(NGX_LOG_ERR, c->log, 0,
+            "http check - SNI disabled because the current version of OpenSSL lacks the support");
+#endif
     }
 
     rc = ngx_ssl_handshake(c);
@@ -3480,6 +3505,21 @@ ngx_http_upstream_check_ssl_protocols(ngx_conf_t *cf, ngx_command_t *cmd,
     return NGX_CONF_OK;
 }
 
+static char *
+ngx_http_upstream_check_ssl_server_name(ngx_conf_t *cf, ngx_command_t *cmd,
+    void *conf)
+{
+    ngx_str_t                           *value;
+    ngx_http_upstream_check_srv_conf_t  *ucscf;
+
+    value = cf->args->elts;
+
+    ucscf = ngx_http_conf_get_module_srv_conf(cf, ngx_http_upstream_check_module);
+
+    ucscf->ssl_server_name = value[1];
+
+    return NGX_CONF_OK;
+}
 
 static char *
 ngx_http_upstream_check_http_expect_alive(ngx_conf_t *cf, ngx_command_t *cmd,


### PR DESCRIPTION
The new field in the upstream `ssl_server_name "server_name";`